### PR TITLE
Fixed TypeScript support in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "./linter.mjs",
   "browser": "./linter.js",
   "files": [
+    "index.d.ts",
     "linter.js",
     "linter.min.js",
     "linter.mjs",
@@ -14,7 +15,10 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
-      "import": "./linter.mjs",
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./linter.mjs"
+      },
       "default": "./linter.cjs"
     },
     "./linter.js": "./linter.js",


### PR DESCRIPTION
Implements the patch at https://github.com/UziTech/eslint-linter-browserify/issues/324

The current bundle for the package does not utilise the index.d.ts type declarations. I have included them and updated them in the package.json accordingly so they can be identified by the TypeScript linter for the development environment.

Please merge these changes to allow the project to be integrated with TypeScript codebases (for example, ReactJS with TypeScript setups)

Understand that this is different than supporting TypeScript for parsing, for which we'll have to patch [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser) accordingly. I have submitted another patch there https://github.com/typescript-eslint/typescript-eslint/issues/7123 to fix https://github.com/UziTech/eslint-linter-browserify/issues/213

